### PR TITLE
Added Go to line number option

### DIFF
--- a/coda
+++ b/coda
@@ -66,7 +66,9 @@ opts = (
     ('-n', '--new-window', {'action': 'store_true', 'dest': 'new_window', 'default': False, 'help': "open in a new window"}),
     ('--ls-tabs', {'action': 'store_true', 'dest': 'lstabs', 'default': False, 'help': 'show all open tabs'}),
     ('--version', {'action': 'store_true', 'default': False, 'help': 'print version information and quit'}),
+    ('-l', '--line', {'dest': 'linenumber', 'default': False, 'help': 'set the current line number of the editor'}),
 )
+
 for opt in opts:
     parser.add_option(*opt[:-1], **opt[-1])
 parser.version = "%%prog: %s" % version
@@ -105,6 +107,21 @@ def new_tab_with_contents(text):
             end tell
             """
     osascript(scpt % (text or "").replace('\\', '\\\\').replace('"', '\\"'))
+
+def goto_line(number):
+    scpt =  """
+            tell application "Coda"
+            	activate
+            	tell application "System Events"
+            		tell application process "Coda"
+            			keystroke "l" using {command down, shift down}
+            			keystroke "%s"
+            			keystroke return
+            		end tell
+            	end tell
+            end tell
+            """
+    osascript(scpt % (number or "1"))
 
 def read_stdin():
     if sys.stdin.isatty(): # not a pipe, wait for more stdin
@@ -194,6 +211,10 @@ if options.chdir:
     if not os.path.isdir(path):
         path = os.path.dirname(path)
     os.system('open -b %s %s' % (bundle_id, quote(path)))
+
+# handle --line
+if options.linenumber:
+    goto_line(options.linenumber)
 
 # handle --wait
 if options.wait:


### PR DESCRIPTION
Added Go to line number option using AppleScript as you do ;). 

Currently it's done sending the shortcut's keystroke "shift+command+l" which is the default. Any idea how to do this if the shortcut is modified?

I did it so I can integrate ir with Ruby's Pry console edit-method command. The only real issue is that optparse doesn't allow single-char options, so the "standard" way of "go to line" of some editors (which is <editor> +LINE FILENAME) can't be done :S. So -l or --line then.
